### PR TITLE
added URL import

### DIFF
--- a/src/imageHash.ts
+++ b/src/imageHash.ts
@@ -4,6 +4,7 @@ import jpeg from 'jpeg-js';
 import { PNG } from 'pngjs';
 import request from 'request';
 import blockhash from './block-hash';
+import { URL } from 'url';
 
 const processPNG = (data, bits, method, cb) => {
   try {


### PR DESCRIPTION
I was experiencing an error when running this on my linux system saying `URL` is not defined.

Error:
```
/home/dsteele/repos/MTG-Card-Analyzer/node_modules/image-hash/lib/imageHash.js:75
            const url = new URL(res.request.uri.href);
                        ^

ReferenceError: URL is not defined
    at Request.handleRequest [as _callback] (/home/dsteele/repos/MTG-Card-Analyzer/node_modules/image-hash/lib/imageHash.js:75:25)
    at Request.self.callback (/home/dsteele/repos/MTG-Card-Analyzer/node_modules/request/request.js:185:22)
    at emitTwo (events.js:126:13)
    at Request.emit (events.js:214:7)
    at Request.<anonymous> (/home/dsteele/repos/MTG-Card-Analyzer/node_modules/request/request.js:1161:10)
    at emitOne (events.js:116:13)
    at Request.emit (events.js:211:7)
    at IncomingMessage.<anonymous> (/home/dsteele/repos/MTG-Card-Analyzer/node_modules/request/request.js:1083:12)
    at Object.onceWrapper (events.js:313:30)
    at emitNone (events.js:111:20)
```