### PR TITLE
Input Types Export Patch

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,10 +1,6 @@
 module.exports = {
   extends: ["airbnb-typescript/base"],
-  env: {
-    "jest": true
-  },
   rules: {
     "no-console": ["error", { allow: ["warn", "error"] }],
-    "prefer-default-export": false,
   }
 };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "types": "lib/imageHash.d.ts",
   "scripts": {
     "test": "npx mocha -r ts-node/register __tests__/*.test.ts ",
-    "build": "tsc"
+    "build": "tsc",
+    "lint": "eslint src/*.ts",
+    "lint:fix": "eslint src/*.ts --fix"
   },
   "files": [
     "lib"

--- a/src/imageHash.ts
+++ b/src/imageHash.ts
@@ -34,15 +34,16 @@ const isUrlRequestObject = (obj: UrlRequestObject | BufferObject): obj is UrlReq
 
 const isBufferObject = (obj: UrlRequestObject | BufferObject): obj is BufferObject => {
   const casted = (obj as BufferObject);
-  return Buffer.isBuffer(casted.data) || (Buffer.isBuffer(casted.data) && (casted.ext && casted.ext.length > 0));
+  return Buffer.isBuffer(casted.data)
+    || (Buffer.isBuffer(casted.data) && (casted.ext && casted.ext.length > 0));
 };
 
-interface UrlRequestObject {
+export interface UrlRequestObject {
   encoding?: string | null,
   url: string | null,
 }
 
-interface BufferObject {
+export interface BufferObject {
   ext?: string,
   data: Buffer,
   name?: string


### PR DESCRIPTION
## Update Exports

Need to export the new input interfaces for `imageHash`.

I noticed this error when testing out the new version in my app.

![type-error](https://user-images.githubusercontent.com/15662762/89129711-6b315200-d4cd-11ea-988d-07307cfc3c8a.png)

## Eslint Fixes

Updated some properties in eslint after `jest` was removed and an `prefer-default-export` was throwing when I was running `eslint` so I removed that too.

Added commands for running linting.