### PR TITLE
Cleanup README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # image-hash
+
 A wrapper around [block-hash](https://github.com/commonsmachinery/blockhash-js) to easily hash a local or remote file with Node.
 
 Supports JPG, PNG and WebP
 
 ## Install
+
 ```bash
 npm i -S image-hash
 ```
 
 ## Use
+
 ```javascript
 const { imageHash }= require('image-hash');
 
@@ -60,6 +63,7 @@ imageHash({
 ```
 
 ## API
+
 ```
 // name
 imageHash(location, bits, precise, callback)

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ interface BufferObject {
 ### Callback Arguments
 
 | Argument | Type                     | Description                                                                         |
-| -------- | ------------------------ | ----------------------------------------------------------------------------------- |  |  |
+| -------- | ------------------------ | ----------------------------------------------------------------------------------- |
 | error    | `Error Object` or `null` | If a run time error is detected this will be an `Error Object`, otherwise `null`    |
 | data     | `string` or `null`       | If there is no run time error, this be will be your hashed result, otherwise `null` |
 

--- a/README.md
+++ b/README.md
@@ -115,4 +115,3 @@ The hard bit of this comes with thanks from [commonsmachinery](https://github.co
 ## License
 
 Distributed under an MIT license
-

--- a/README.md
+++ b/README.md
@@ -101,9 +101,11 @@ interface BufferObject {
 | data     | `string` or `null`       | If there is no run time error, this be will be your hashed result, otherwise `null` |
 
 ## Development
+
 I have made this with Typescript, ESLint, Jest, Babel and VSCode. All config files and global binaries are included. For developers using VS Code, make sure you have ESLint extension installed.
 
 ## Testing
+
 `npm test`
 
 ## Credit

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ interface UrlRequestObject {
   encoding?: string | null,
   url: string | null,
 };
+
 // Buffer Object
 interface BufferObject {
   ext?: string, // mime type of buffered file

--- a/README.md
+++ b/README.md
@@ -70,12 +70,12 @@ imageHash(string|object, int, bool, function)
 
 ### Image-Hash Arguments
 
-| Argument | Type                 | Description                                                                                                                                                                                                                                                                                                                                                  | Mandatory | Example   |
-| -------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------- | --------- |
-| location | `object` or `string` | A [RequestJS Object](https://github.com/request/request#requestoptions-callback), `Buffer` object (See input types below for more details), or `String` with a valid url or file location                                                                                                                                                                                                                               | Yes       | see above |
-| bits     | `int`                | The number of bits in a row. The more bits, the more unique the hash.                                                                                                                                                                                                                                                                                        | Yes       | 8         |
-| precise  | `bool`               | Whether a precision algorithm is used. `true` Precise but slower, non-overlapping blocks. `false` Quick and crude, non-overlapping blocks. Method 2 is recommended as a good tradeoff between speed and good matches on any image size. The quick ones are only advisable when the image width and height are an even multiple of the number of blocks used. | Yes       | `true`    |
-| callback | `function`           | A function with `error` and `data` arguments - see below                                                                                                                                                                                                                                                                                                     |
+| Argument | Type | Description | Mandatory | Example |
+| -------- | ---- | ----------- | --------- | ------- |
+| location | `object` or `string` | A [RequestJS Object](https://github.com/request/request#requestoptions-callback), `Buffer` object (See input types below for more details), or `String` with a valid url or file location | Yes | see above |
+| bits | `int` | The number of bits in a row. The more bits, the more unique the hash. | Yes | 8 |
+| precise  | `bool` | Whether a precision algorithm is used. `true` Precise but slower, non-overlapping blocks. `false` Quick and crude, non-overlapping blocks. Method 2 is recommended as a good tradeoff between speed and good matches on any image size. The quick ones are only advisable when the image width and height are an even multiple of the number of blocks used. | Yes | `true` |
+| callback | `function` | A function with `error` and `data` arguments - see below |
 
 #### Location Object Types
 

--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ imageHash({
 
 ## API
 
-```
+```typescript
 // name
-imageHash(location, bits, precise, callback)
+imageHash(location, bits, precise, callback);
 
 // types
-imageHash(string|object, int, bool, function)
+imageHash(string|object, int, bool, function);
 ```
 
 ### Image-Hash Arguments


### PR DESCRIPTION
This PR cleans up a number of formatting issues with the repository's readme, including

- Fix Callback Arguments table being formatted incorrectly
- Add extra spaces below applicable markdown headers to be consistent with the rest of the readme
- Remove extraneous amounts of spacing and dashes in Image-Hash Arguments table
- Add missing `typescript` codeblock header
- Add and Remove an extra newline where appropriate